### PR TITLE
use ObservableCollection of enum type CloudAnimationType 

### DIFF
--- a/Controls/CustomCloudControl.xaml
+++ b/Controls/CustomCloudControl.xaml
@@ -10,10 +10,19 @@
 
     
     <Border 
-        BackgroundColor="Aquamarine"
+        BackgroundColor="Teal"
         StrokeThickness="2"
         AutomationId="25"
         ZIndex="2">
+        <Label
+            x:Name="loopLabel"
+            Text="start"
+            FontSize="90"
+            VerticalOptions="Start"
+            HorizontalOptions="End"
+            TextColor="Yellow"
+            FontAttributes="Bold"
+            ZIndex="9"/>
         <Border.Stroke>
             <LinearGradientBrush EndPoint="1,0">
                 <GradientStop Color="Purple"

--- a/Controls/CustomCloudControl.xaml.cs
+++ b/Controls/CustomCloudControl.xaml.cs
@@ -1,4 +1,5 @@
 
+using Microsoft.Maui.Graphics;
 using System.Threading.Tasks;
 
 namespace WriteToCompassion.Controls;
@@ -6,14 +7,25 @@ namespace WriteToCompassion.Controls;
 
 public partial class CustomCloudControl : ContentView
 {
+    public static int loopCounter = 0;
+
+
+
     public static readonly BindableProperty CloudAnimationProperty =
-     BindableProperty.Create(nameof(CloudAnimation), typeof(CloudAnimationType), typeof(CustomCloudControl), CloudAnimationType.None,
-     propertyChanged: OnCloudAnimationChanged);
+ BindableProperty.Create(nameof(CloudAnimation), typeof(CloudAnimationType), typeof(CustomCloudControl), CloudAnimationType.None, defaultBindingMode: BindingMode.TwoWay, propertyChanged: OnCloudAnimationChanged);
+
 
     public CloudAnimationType CloudAnimation
     {
         get => (CloudAnimationType)GetValue(CloudAnimationProperty);
-        set => SetValue(CloudAnimationProperty, value);
+        set
+        {
+/*            if (this.CloudAnimation == value)
+                return;
+*/
+            SetValue(CloudAnimationProperty, value);
+
+        }
     }
 
     static async void OnCloudAnimationChanged(BindableObject bindable, object oldValue, object newValue)
@@ -28,8 +40,11 @@ public partial class CustomCloudControl : ContentView
                 break;
 
             case CloudAnimationType.Drift:
-                await cloudReportingChange.DriftAround();
-                break;
+                {
+                    await cloudReportingChange.DriftAround();
+                    break;
+                }
+
 
             case CloudAnimationType.Hover:
                 await cloudReportingChange.LocalHover();
@@ -40,6 +55,7 @@ public partial class CustomCloudControl : ContentView
                 break;
         }
     }
+
 
 
     AnimationService cloudAnimationService;
@@ -65,15 +81,50 @@ public partial class CustomCloudControl : ContentView
 
     public async Task DriftAround()
     {
+        bool colorBool = false;
         this.CancelAnimations();
         cloudAnimationService.SetRandomDriftTranslationTargets(out double x, out double y, out uint durationRandom);
-        do
+        await this.TranslateTo(x, y, 5000, easing: Easing.SinInOut);
+
+        loopCounter++;
+        loopLabel.Text = loopCounter.ToString();
+        while (true)
         {
+
             await this.TranslateTo(x, y, 5000, easing: Easing.SinInOut);
+            loopCounter++;
+            loopLabel.Text = loopCounter.ToString();
+            if (colorBool)
+                this.BackgroundColor = Colors.BlueViolet;
+            else
+                this.BackgroundColor = Colors.Red;
+            colorBool = !colorBool;
             cloudAnimationService.SetRandomDriftTranslationTargets(out x, out y, out durationRandom);
 
-        } while (this.CloudAnimation == CloudAnimationType.Drift);
+        }
     }
+
+    /*    public async Task DriftAround()
+        {
+            bool colorBool = false;
+            this.CancelAnimations();
+            cloudAnimationService.SetRandomDriftTranslationTargets(out double x, out double y, out uint durationRandom);
+            loopCounter++;
+            loopLabel.Text = loopCounter.ToString();
+            do
+            {
+                loopCounter++;
+                loopLabel.Text = loopCounter.ToString();
+                await this.TranslateTo(x, y, 5000, easing: Easing.SinInOut);
+                if(colorBool)
+                    this.BackgroundColor = Colors.BlueViolet;
+                else
+                    this.BackgroundColor = Colors.Red;
+                colorBool = !colorBool;
+                cloudAnimationService.SetRandomDriftTranslationTargets(out x, out y, out durationRandom);
+
+            } while (this.CloudAnimation == CloudAnimationType.Drift);
+        }*/
 
     public async Task Dance()
     {

--- a/Converters/CloudAnimationTypeConverter.cs
+++ b/Converters/CloudAnimationTypeConverter.cs
@@ -1,0 +1,20 @@
+﻿using WriteToCompassion.Controls;
+using System.Globalization;
+
+namespace WriteToCompassion.Converters;
+
+public class CloudAnimationTypeConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+
+        return (CloudAnimationType)value != 0;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return null;
+    }
+
+
+}

--- a/Models/Cloud.cs
+++ b/Models/Cloud.cs
@@ -1,0 +1,8 @@
+﻿
+namespace WriteToCompassion.Models;
+
+public class Cloud
+{
+    public CloudAnimationType CAT { get; set; }
+
+}

--- a/Services/AnimationService.cs
+++ b/Services/AnimationService.cs
@@ -22,21 +22,11 @@ public partial class AnimationService : ObservableObject
 
     private void SetVerticalBoundaries()
     {
-        //TODO: Redo math on boundaries now that grids have changed
-
         double yBoundary = ScreenHelper.ScreenYValue;
 
-        //subtracting bottom grid cell set to 50 units
-        yBoundary -= 50;
+        // ratio of space for Grid.Row = 1
+        yBoundary *= .75;
 
-        // 5*, * grid sizes for first two cells means 6 total units
-        yBoundary /= 6;
-
-        // * units in the clouds grid cell (5)
-        yBoundary *= 5;
-
-        //subtracting aesthetic buffer
-        yBoundary -= 70;
 
 
 

--- a/ViewModels/HomeViewModel.cs
+++ b/ViewModels/HomeViewModel.cs
@@ -11,6 +11,11 @@ public partial class HomeViewModel : BaseViewModel
 {
     public ObservableCollection<CustomCloudControl> CloudControls { get; set; } = new();
 
+    public ObservableCollection<CloudAnimationType> Clouds { get; set; } = new();
+
+    [ObservableProperty]
+    public Cloud testCloud = new();
+
     public ObservableCollection<Thought> UnreadThoughts { get; } = new();
 
     public ObservableCollection<Thought> AllThoughts { get; } = new();
@@ -26,7 +31,7 @@ public partial class HomeViewModel : BaseViewModel
     double cloudScale = 0.5;
 
     [ObservableProperty]
-    int maxClouds = 7;
+    int maxClouds = 1;
 
     [ObservableProperty]
     bool unreadOnly = true;
@@ -36,91 +41,6 @@ public partial class HomeViewModel : BaseViewModel
 
     [ObservableProperty]
     bool cloudTextVisible;
-
-    #region CloudAnimationTypes for MVVM Bindings
-
-    private CloudAnimationType _cloud1Animation;
-    public CloudAnimationType Cloud1Animation
-    {
-        get => _cloud1Animation;
-        set
-        {
-            if (_cloud1Animation != value)
-            {
-                _cloud1Animation = value;
-                OnPropertyChanged();
-
-            }
-
-        }
-    }
-
-    private CloudAnimationType _cloud2Animation;
-    public CloudAnimationType Cloud2Animation
-    {
-        get => _cloud2Animation;
-        set
-        {
-            if (_cloud2Animation != value)
-            {
-                _cloud2Animation = value;
-                OnPropertyChanged();
-
-            }
-
-        }
-    }
-
-    private CloudAnimationType _cloud3Animation;
-    public CloudAnimationType Cloud3Animation
-    {
-        get => _cloud3Animation;
-        set
-        {
-            if (_cloud3Animation != value)
-            {
-                _cloud3Animation = value;
-                OnPropertyChanged();
-
-            }
-
-        }
-    }
-
-    private CloudAnimationType _cloud4Animation;
-    public CloudAnimationType Cloud4Animation
-    {
-        get => _cloud4Animation;
-        set
-        {
-            if (_cloud4Animation != value)
-            {
-                _cloud4Animation = value;
-                OnPropertyChanged();
-
-            }
-
-        }
-    }
-
-    private CloudAnimationType _cloud5Animation;
-    public CloudAnimationType Cloud5Animation
-    {
-        get => _cloud5Animation;
-        set
-        {
-            if (_cloud5Animation != value)
-            {
-                _cloud5Animation = value;
-                OnPropertyChanged();
-
-            }
-
-        }
-    }
-
-    #endregion
-
 
     public HomeViewModel(ThoughtsService thoughtsService, ISettingsService settingsService)
             : base(settingsService)
@@ -172,11 +92,11 @@ public partial class HomeViewModel : BaseViewModel
 
         for (int i = 0; i < cloudCount; i++)
         {
-            CustomCloudControl c = new()
+            CloudAnimationType c = new()
             {
-                CloudAnimation = CloudAnimationType.Drift
+
             };
-            CloudControls.Add(c);
+            Clouds.Add(c);
         }
     }
 
@@ -201,7 +121,12 @@ public partial class HomeViewModel : BaseViewModel
         await Shell.Current.DisplayAlert($"Swipe up--- {index}", "cloud command", "ok");
     }
 
+    [RelayCommand]
+    async Task CloudPropertyChange()
+    {
+        Clouds[0] = CloudAnimationType.Drift;
 
+    }
 
 
     //navigation

--- a/Views/HomeView.xaml
+++ b/Views/HomeView.xaml
@@ -47,7 +47,8 @@
         RowDefinitions="*,3*"
         Padding="15">
 
-        <Border 
+        <Border
+            x:Name="contentBorder"
             Grid.Row="0"
             BackgroundColor="Transparent"
             ZIndex="4">
@@ -67,24 +68,47 @@
             </Border.GestureRecognizers>
         </Border>
 
+
+        <controls:CustomCloudControl
+            Grid.Row="1"
+            IsVisible="false"
+            x:Name="testCloudControl"
+            HorizontalOptions="Center"
+            VerticalOptions="End"
+            WidthRequest="200"
+            HeightRequest="126"
+            ZIndex="2"
+            CloudAnimation="{Binding Clouds}">
+        </controls:CustomCloudControl>
+
+        <Label 
+            Text="starting text"
+            Grid.Row="1"
+            x:Name="testLabel"
+            FontSize="30"
+            TextColor="HotPink"
+            VerticalOptions="End"
+            HorizontalOptions="End"/>
+
         <!--Custom Cloud Controls-->
         <!--Height and Width set according to SVG pixel dimensions-->
         <!--TapGestureRecognizer inside CustomCloudControl xaml-->
         <Grid
+            x:Name="cloudGrid"
             Grid.Row="1"
-            BindableLayout.ItemsSource="{Binding CloudControls}">
+            BindableLayout.ItemsSource="{Binding Clouds}">
             <BindableLayout.ItemTemplate>
-                <DataTemplate x:DataType="controls:CustomCloudControl">
+                <DataTemplate x:DataType="controls:CloudAnimationType">
                     <controls:CustomCloudControl
+                        IsVisible="true"
                         HorizontalOptions="Center"
                         VerticalOptions="End"
                         WidthRequest="200"
                         HeightRequest="126"
                         ZIndex="2"
-                        BackgroundColor="Pink"
-                        CloudAnimation="{Binding CloudAnimation, Mode=TwoWay}"
+                        CloudAnimation="{Binding .}"
                         Scale="{Binding Source={x:RelativeSource AncestorType={x:Type viewmodels:HomeViewModel}}, Path=CloudScale}">
-                        </controls:CustomCloudControl>
+                    </controls:CustomCloudControl>
                 </DataTemplate>
             </BindableLayout.ItemTemplate>
         </Grid>
@@ -101,8 +125,40 @@
                             ZIndex="0"
                             RepeatCount="-1"
                             Source="bigcloudlottie.json"/>
-        <HorizontalStackLayout>
-
+        <HorizontalStackLayout
+            VerticalOptions="End"
+            Grid.Row="1">
+            <Label
+                Margin="10"
+                HorizontalTextAlignment="End"
+                x:Name="sizeLabel"
+                Text="initial"
+                FontSize="Micro"
+                TextColor="DarkOrange"/>
+            <Button
+                HorizontalOptions="End"
+                x:Name="sizeButton"
+                FontAutoScalingEnabled="True"
+                Text="measure"
+                FontSize="Micro"
+                TextColor="OrangeRed"
+                Clicked="OnMeasureClicked"/>
+            <Button
+                HorizontalOptions="End"
+                x:Name="prop"
+                FontAutoScalingEnabled="True"
+                Text="propchange"
+                FontSize="Micro"
+                TextColor="YellowGreen"
+                Command="{Binding CloudPropertyChangeCommand}"/>
+            <Button
+                HorizontalOptions="End"
+                x:Name="workButton"
+                FontAutoScalingEnabled="True"
+                Text="$"
+                FontSize="Micro"
+                TextColor="IndianRed"
+                Clicked="workButton_Clicked"/>
         </HorizontalStackLayout>
 
 

--- a/Views/HomeView.xaml.cs
+++ b/Views/HomeView.xaml.cs
@@ -1,13 +1,14 @@
-using Microsoft.Maui;
-
+using System.Text;
 namespace WriteToCompassion.Views;
 
 public partial class HomeView : ContentPage
 {
+    private readonly HomeViewModel homeViewModel;
 	public HomeView(HomeViewModel homeViewModel)
 	{
 		InitializeComponent();
 		BindingContext = homeViewModel;
+        this.homeViewModel = homeViewModel;
 	}
 
     protected override void OnSizeAllocated(double width, double height)
@@ -22,79 +23,37 @@ public partial class HomeView : ContentPage
     }
 
 
-/*    private async void AnimateBox()
+    private void OnMeasureClicked(object sender, EventArgs e)
     {
-        var startingX = box.TranslationX;
-        var startingY = box.TranslationY;
-        do
-        {
-            box.CancelAnimations();
-            await box.TranslateTo(startingX - 50, startingY - 50, 3000);
-            await box.TranslateTo(startingX - 50, startingY, 3000);
-            await box.TranslateTo(startingX, startingY - 50, 3000);
-            await box.TranslateTo(startingX, startingY, 3000);
-        } while (true);
-    }*/
-
-    private void OnBoxPanUpdated(object sender, PanUpdatedEventArgs e)
-    {
-
+        StringBuilder sb = new StringBuilder();
+        sb.Append("Base: ");
+        sb.Append("   w " + base.Width.ToString("F1"));
+        sb.AppendLine("   h " + base.Height.ToString("F1"));
+        sb.Append("pad: ");
+        sb.Append("   horiz   " + base.Padding.HorizontalThickness);
+        sb.AppendLine("   vert   " + base.Padding.VerticalThickness);
+        sb.Append("Grid 0: ");
+        sb.Append("   w " + contentBorder.Width.ToString("F1"));
+        sb.AppendLine("   h " + contentBorder.Height.ToString("F1"));
+        sb.Append("pad: ");
+        sb.Append("   horiz   " + contentBorder.Padding.HorizontalThickness);
+        sb.AppendLine("   vert   " + contentBorder.Padding.VerticalThickness);
+        sb.Append("Grid 1: ");
+        sb.Append("   w " + cloudGrid.Width.ToString("F1"));
+        sb.AppendLine("   h " + cloudGrid.Height.ToString("F1"));
+        sb.Append("pad: ");
+        sb.Append("   horiz   " + cloudGrid.Padding.HorizontalThickness);
+        sb.AppendLine("   vert   " + cloudGrid.Padding.VerticalThickness);
+        sizeLabel.Text = sb.ToString();
     }
 
-    private void OnSwiped(object sender, SwipedEventArgs e)
+    private void prop_Clicked(object sender, EventArgs e)
     {
-        Shell.Current.DisplayAlert("helper", e.Direction.ToString(), "ok");
     }
 
-    /*        switch (e.StatusType)
-        {
-            case GestureStatus.Running:
-                HandleTouch(e.TotalX, e.TotalY);
-                break;
-            case GestureStatus.Completed:
-                HandleTouchEnd(swipedDirection);
-                break;
-        }*/
-
-
-    /*    private void HandleTouch(double eTotalX, double eTotalY)
-        {
-            swipedDirection = null;
-            const int delta = 50;
-            if (eTotalX > delta)
-            {
-                swipedDirection = SwipeDirection.Right;
-            }
-            else if (eTotalX < -delta)
-            {
-                swipedDirection = SwipeDirection.Left;
-            }
-            else if (eTotalY > delta)
-            {
-                swipedDirection = SwipeDirection.Down;
-            }
-            else if (eTotalY < -delta)
-            {
-                swipedDirection = SwipeDirection.Up;
-            }
-        }
-
-        private void HandleTouchEnd(SwipeDirection? swiped)
-        {
-            if (swiped == null)
-            {
-                return;
-            }
-
-            switch (swiped)
-            {
-                case SwipeDirection.Right when Children.Count > 0:
-                    cards.Push(Children[^1]);
-                    Children.RemoveAt(Children.Count - 1);
-                    break;
-                case SwipeDirection.Left when cards.Count > 0:
-                    Children.Add(cards.Pop());
-                    break;
-            }
-        }*/
+    private void workButton_Clicked(object sender, EventArgs e)
+    {
+/*        testCloudControl.CloudAnimation = homeViewModel.Clouds[0];
+        testLabel.Text = testCloudControl.CloudAnimation.ToString();*/
+    }
 }


### PR DESCRIPTION
Improved performance by using the enum collection instead of the previous ObservableCollection of type CustomCloudControl to spawn clouds on HomeView. Using CustomCloudControl as a collection resulted in 2 sets of controls (only 1 visible) which resulted in 2 NotifyPropChange events being raised when changing CloudAnimation on the controls. This cuts the awaited tasks in half